### PR TITLE
fix chokidar watch flake

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,11 @@ const document = new EditableNetworkedDOM(
 document.load(getDomFileContents());
 
 // Watch for changes in the DOM file and reload
-chokidar.watch(filePath).on("change", () => {
+chokidar.watch(filePath, {
+  awaitWriteFinish: {
+      stabilityThreshold: 100
+  }
+}).on("change", () => {
   document.load(getDomFileContents());
 });
 


### PR DESCRIPTION
Fix chokidar flake where mml document change watcher fails to correctly update visualization (especially prevalent with vscode).

**What kind of change does your PR introduce?** (check at least one)

- [X] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Tests
- [ ] Other, please describe:

